### PR TITLE
Improved htmlAttributes and meta types.

### DIFF
--- a/src/BsReactHelmet.re
+++ b/src/BsReactHelmet.re
@@ -1,7 +1,16 @@
-type htmlAttributes;
+[@bs.deriving abstract]
+type htmlAttributes = {lang: string};
 type bodyAttributes;
 type titleAttributes;
-type meta;
+[@bs.deriving abstract]
+type meta = {
+  [@bs.optional]
+  name: string,
+  [@bs.optional]
+  property: string,
+  [@bs.optional]
+  content: string,
+};
 type base;
 type link;
 type style;
@@ -50,4 +59,4 @@ type helmet = {
   "title": helmetProp,
 };
 [@bs.val] [@bs.module "react-helmet"] [@bs.scope "Helmet"]
-external renderStatic: unit => helmet = "";
+external renderStatic: unit => helmet = "renderStatic";


### PR DESCRIPTION
This expands a few of the abstract types with `[@bs.deriving abstract]` records. It’s a quick-and-dirty change, so doesn’t thoroughly account for every type or field yet, but it was necessary to use with my own project.

I also changed the `renderStatic` method just to avoid getting warnings about it.